### PR TITLE
chore: Added Ruff linter configuration

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,62 @@
+line-length = 120
+target-version = "py313"
+
+[lint]
+select = [
+    "E",
+    "F",
+    "FAST",
+    "YTT",
+    "ANN",
+    "ASYNC",
+    "S",
+    "B",
+    "A",
+    "COM",
+    "C4",
+    "EXE",
+    "INT",
+    "ISC",
+    "ICN",
+    "LOG",
+    "G",
+    "INP",
+    "PIE",
+    "T20",
+    "PYI",
+    "PT",
+    "Q",
+    "RSE",
+    "RET",
+    "SIM",
+    "TID",
+    "TC",
+    "FLY",
+    "I",
+    "PERF",
+    "W",
+    "UP",
+    "FURB",
+    "RUF"
+]
+ignore = [
+    "E741",     # https://docs.astral.sh/ruff/rules/ambiguous-variable-name/
+    "E501",     # https://docs.astral.sh/ruff/rules/line-too-long/
+    "FAST003",  # https://docs.astral.sh/ruff/rules/fast-api-unused-path-parameter/
+    "ANN401",   # https://docs.astral.sh/ruff/rules/any-type/
+    "S101",     # https://docs.astral.sh/ruff/rules/assert/
+    "S110",     # https://docs.astral.sh/ruff/rules/try-except-pass/
+    "S311",     # https://docs.astral.sh/ruff/rules/suspicious-non-cryptographic-random-usage/
+    "B904",     # https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/
+    "PT012",    # https://docs.astral.sh/ruff/rules/pytest-raises-with-multiple-statements/
+    "PT011",    # https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/
+    "SIM115",   # https://docs.astral.sh/ruff/rules/open-file-with-context-handler/
+    "RUF001",   # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-string/
+    "RUF002",   # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-docstring/
+    "RUF003",   # https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-comment/
+    "RUF018",   # https://docs.astral.sh/ruff/rules/assignment-in-assert/
+    "RUF012",   # https://docs.astral.sh/ruff/rules/mutable-class-default/
+]
+
+[lint.flake8-annotations]
+mypy-init-return = true


### PR DESCRIPTION
## Description
This PR adds `Ruff` as the linter for the project, with configuration defined in a `ruff.toml` file.