### PR TITLE
feat: Enabled CORS for frontend integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,21 @@
 import uvicorn
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
+
+# enable CORS related config
+origins = [
+    "http://localhost:5173",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/")


### PR DESCRIPTION
## Description
This PR adds the necessary CORS configuration to the FastAPI backend to allow communication with the `simulation-ui` app running on `http://localhost:5173` currently.