### PR TITLE
chore: Updated Ruff line length limit

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-line-length = 120
+line-length = 88
 target-version = "py313"
 
 [lint]

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,7 +4,10 @@ from .models import CountyName, EarthquakeData, EarthquakeEvent, SeverityLevel
 def generate_events(data: EarthquakeData) -> list[EarthquakeEvent]:
     events = []
     magnitude = float(data.magnitude_value)
-    county_intensity_map = {area.county_name: float(area.area_intensity) for area in (data.shaking_area or [])}
+    county_intensity_map = {
+        area.county_name: float(area.area_intensity)
+        for area in (data.shaking_area or [])
+    }
 
     for county in CountyName:
         # get intensity value for the county


### PR DESCRIPTION
## Description
This PR reduces Ruff's `line-length` setting from 120 to 88 to improve code readability by encouraging line breaks for long expressions. This helps avoid dense one-liners and promotes cleaner formatting, especially for function calls and complex logic.