### PR TITLE
chore: Added env example for CORS config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+FRONTEND_BASE_URL=http://localhost:5173


### PR DESCRIPTION
## Description
This PR added `FRONTEND_BASE_URL` to the environment variable example to support proper CORS setup during local development.