### PR TITLE
feat: Added earthquake data observation metrics

### DIFF
--- a/app/routers/earthquake.py
+++ b/app/routers/earthquake.py
@@ -2,11 +2,15 @@ from fastapi import APIRouter, Response, status
 
 from app.models.earthquake import EarthquakeData
 from app.services.earthquake import generate_events
+from app.services.metrics import observe_earthquake_data
 
 router = APIRouter()
 
 
 @router.post("/earthquake")
 def create_earthquake(data: EarthquakeData) -> Response:
+    # update metrics for earthquake data
+    observe_earthquake_data(data)
+
     generate_events(data)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -1,3 +1,5 @@
+import uuid
+
 from prometheus_client import Counter, Gauge
 
 from app.models.earthquake import EarthquakeData
@@ -5,19 +7,36 @@ from app.models.earthquake import EarthquakeData
 # --- Earthquake data metrics ---
 earthquake_occurrences = Counter(
     "earthquake_occurrences",
-    "Total number of earthquake data received",
+    "Total number of earthquake data",
     ["source"],
 )
 earthquake_magnitude = Gauge(
     "earthquake_magnitude",
-    "Magnitude value of earthquake",
-    ["source", "location"],
+    "Magnitude value of earthquake data",
+    ["source", "id", "location"],
+)
+earthquake_depth = Gauge(
+    "earthquake_depth",
+    "Focal depth of earthquake data",
+    ["source", "id", "location"],
 )
 
 
 def observe_earthquake_data(data: EarthquakeData) -> None:
+    # generate unique id
+    earthquake_id = str(uuid.uuid4())
+
+    # increment occurrence counter
     earthquake_occurrences.labels(source=data.source).inc()
+
+    # set magnitude and depth value
     earthquake_magnitude.labels(
+        id=earthquake_id,
         source=data.source,
         location=data.epicenter_location,
     ).set(data.magnitude_value)
+    earthquake_depth.labels(
+        id=earthquake_id,
+        source=data.source,
+        location=data.epicenter_location,
+    ).set(data.focal_depth)

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -5,8 +5,8 @@ from prometheus_client import Counter, Gauge
 from app.models.earthquake import EarthquakeData
 
 # --- Earthquake data metrics ---
-earthquake_occurrences = Counter(
-    "earthquake_occurrences",
+earthquake_occurrences_total = Counter(
+    "earthquake_occurrences_total",
     "Total number of earthquake data",
     ["source"],
 )
@@ -27,7 +27,7 @@ def observe_earthquake_data(data: EarthquakeData) -> None:
     earthquake_id = str(uuid.uuid4())
 
     # increment occurrence counter
-    earthquake_occurrences.labels(source=data.source).inc()
+    earthquake_occurrences_total.labels(source=data.source).inc()
 
     # set magnitude and depth value
     earthquake_magnitude.labels(

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -13,12 +13,12 @@ earthquake_occurrences = Counter(
 earthquake_magnitude = Gauge(
     "earthquake_magnitude",
     "Magnitude value of earthquake data",
-    ["source", "id", "location"],
+    ["source", "id", "epicenter"],
 )
 earthquake_depth = Gauge(
     "earthquake_depth",
     "Focal depth of earthquake data",
-    ["source", "id", "location"],
+    ["source", "id", "epicenter"],
 )
 
 
@@ -33,10 +33,10 @@ def observe_earthquake_data(data: EarthquakeData) -> None:
     earthquake_magnitude.labels(
         id=earthquake_id,
         source=data.source,
-        location=data.epicenter_location,
+        epicenter=data.epicenter_location,
     ).set(data.magnitude_value)
     earthquake_depth.labels(
         id=earthquake_id,
         source=data.source,
-        location=data.epicenter_location,
+        epicenter=data.epicenter_location,
     ).set(data.focal_depth)

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -1,0 +1,23 @@
+from prometheus_client import Counter, Gauge
+
+from app.models.earthquake import EarthquakeData
+
+# --- Earthquake data metrics ---
+earthquake_occurrences = Counter(
+    "earthquake_occurrences",
+    "Total number of earthquake data received",
+    ["source"],
+)
+earthquake_magnitude = Gauge(
+    "earthquake_magnitude",
+    "Magnitude value of earthquake",
+    ["source", "location"],
+)
+
+
+def observe_earthquake_data(data: EarthquakeData) -> None:
+    earthquake_occurrences.labels(source=data.source).inc()
+    earthquake_magnitude.labels(
+        source=data.source,
+        location=data.epicenter_location,
+    ).set(data.magnitude_value)


### PR DESCRIPTION
## Description
This PR introduces Prometheus metrics to monitor incoming earthquake data:
- `earthquake_occurrences`: Tracks the total number of earthquake data received.
- `earthquake_magnitude`: Captures the magnitude value of each earthquake data.
- `earthquake_depth`: Captures the focal depth of each earthquake data.

## Screenshot
<img width="563" alt="image" src="https://github.com/user-attachments/assets/7b40e75f-8cb2-4255-b055-9687c3f68bdb" />
