### PR TITLE
fix: Resolved earthquake data type

### DIFF
--- a/app/models/earthquake.py
+++ b/app/models/earthquake.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .base import CustomBaseModel
 from .enums import Location, SeverityLevel
@@ -8,16 +8,16 @@ from .enums import Location, SeverityLevel
 
 class ShakingArea(CustomBaseModel):
     county_name: Location
-    area_intensity: str
+    area_intensity: float
 
 
 class EarthquakeData(CustomBaseModel):
     source: str
     origin_time: datetime
     epicenter_location: str
-    magnitude_value: str
-    focal_depth: str
-    shaking_area: list[ShakingArea] | None = None
+    magnitude_value: float
+    focal_depth: float
+    shaking_area: list[ShakingArea] = Field(default_factory=list)
 
 
 class EarthquakeEvent(BaseModel):

--- a/app/services/earthquake.py
+++ b/app/services/earthquake.py
@@ -4,10 +4,9 @@ from app.models.enums import Location, SeverityLevel
 
 def generate_events(data: EarthquakeData) -> list[EarthquakeEvent]:
     events = []
-    magnitude = float(data.magnitude_value)
+    magnitude = data.magnitude_value
     county_intensity_map = {
-        area.county_name: float(area.area_intensity)
-        for area in (data.shaking_area or [])
+        area.county_name: area.area_intensity for area in data.shaking_area
     }
 
     for location in Location:


### PR DESCRIPTION
## Description
This PR made the following changes:
- Updated type annotations for certain fields in the `EarthquakeData` model from str to float where applicable (`magnitude_value`, `focal_depth`, etc.) to eliminate the need for runtime casting.
- Set a default value for `shaking_area` using `Field(default_factory=list)` to ensure it defaults to an empty list instead of None.