### PR TITLE
feat: Added earthquake area intensity metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
-FRONTEND_BASE_URL=http://localhost:5173
-
 # === Redis ===
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/app/main.py
+++ b/app/main.py
@@ -1,25 +1,16 @@
-import os
-
-from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.routers import earthquake
 
-# load env variables
-load_dotenv()
-
 app = FastAPI()
 Instrumentator().instrument(app).expose(app)
 
 # enable CORS related config
-origins = [
-    os.environ.get("FRONTEND_BASE_URL"),
-]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -18,6 +18,11 @@ earthquake_depth = Gauge(
     "Focal depth of earthquake data",
     ["source", "id", "epicenter"],
 )
+earthquake_intensity = Gauge(
+    "earthquake_intensity",
+    "Area intensity of earthquake data",
+    ["source", "id", "area"],
+)
 
 
 def observe_earthquake_data(data: EarthquakeData) -> None:
@@ -35,3 +40,11 @@ def observe_earthquake_data(data: EarthquakeData) -> None:
         source=data.source,
         epicenter=data.epicenter_location,
     ).set(data.focal_depth)
+
+    # set intensity for each area
+    for area in data.shaking_area:
+        earthquake_intensity.labels(
+            id=str(data.id),
+            source=data.source,
+            area=area.county_name.value,
+        ).set(area.area_intensity)


### PR DESCRIPTION
## Description 
This PR introduces two key changes:

1. Prometheus Metrics:
   - Added a new `earthquake_intensity` gauge metric to export area-wise earthquake intensity.
   - Metric is labeled with source, id, and area, and populated for each `shaking_area` from the earthquake data payload.

2. CORS Configuration:
   - Removed use of the `FRONTEND_BASE_URL` environment variable.
   - Replaced with a wildcard (`"*"`), allowing requests from any origin.