### PR TITLE
feat: Add Prometheus event and alert metrics

### DIFF
--- a/app/models/earthquake.py
+++ b/app/models/earthquake.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, Field
 
 from .base import CustomBaseModel
-from .enums import Location, SeverityLevel
+from .enums import Location, SeverityLevel, TriState
 
 
 class ShakingArea(CustomBaseModel):
@@ -36,5 +36,6 @@ class EarthquakeAlert(BaseModel):
     origin_time: datetime
     location: Location
     severity_level: SeverityLevel
-    status: str
-    processing_furation: int
+    has_damage: TriState
+    needs_command_center: TriState
+    processing_duration: int

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -12,3 +12,9 @@ class SeverityLevel(str, Enum):
     NA = "NA"
     L1 = "L1"
     L2 = "L2"
+
+
+class TriState(str, Enum):
+    TRUE = "true"
+    FALSE = "false"
+    UNKNOWN = "unknown"

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -15,6 +15,6 @@ class SeverityLevel(str, Enum):
 
 
 class TriState(str, Enum):
-    TRUE = "true"
-    FALSE = "false"
-    UNKNOWN = "unknown"
+    TRUE = 1
+    FALSE = 0
+    UNKNOWN = -1

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -14,7 +14,7 @@ class SeverityLevel(str, Enum):
     L2 = "L2"
 
 
-class TriState(str, Enum):
+class TriState(int, Enum):
     TRUE = 1
     FALSE = 0
     UNKNOWN = -1

--- a/app/routers/earthquake.py
+++ b/app/routers/earthquake.py
@@ -2,7 +2,11 @@ from fastapi import APIRouter
 
 from app.models.earthquake import EarthquakeAlert, EarthquakeData
 from app.services.earthquake import generate_alerts, generate_events
-from app.services.metrics import observe_earthquake_data
+from app.services.metrics import (
+    observe_earthquake_alerts,
+    observe_earthquake_data,
+    observe_earthquake_events,
+)
 
 router = APIRouter(prefix="/api/earthquake", tags=["earthquake"])
 
@@ -14,4 +18,7 @@ def create_earthquake(data: EarthquakeData) -> list[EarthquakeAlert]:
 
     # obtain alerts by filtering events
     events = generate_events(data)
-    return generate_alerts(events)
+    observe_earthquake_events(events)
+    alerts = generate_alerts(events)
+    observe_earthquake_alerts(alerts)
+    return alerts

--- a/app/services/earthquake.py
+++ b/app/services/earthquake.py
@@ -69,7 +69,7 @@ def generate_alerts(events: list[EarthquakeEvent]) -> list[EarthquakeAlert]:
                 severity_level=event.severity_level,
                 has_damage=TriState.UNKNOWN,
                 needs_command_center=TriState.UNKNOWN,
-                processing_furation=0,  # Add real logic later
+                processing_duration=0,  # Add real logic later
             )
             alerts.append(alert)
             redis_client.set(redis_key, alert.model_dump_json())

--- a/app/services/earthquake.py
+++ b/app/services/earthquake.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from app.core.redis import get_alert_suppress_time, redis_client
 from app.models.earthquake import EarthquakeAlert, EarthquakeData, EarthquakeEvent
-from app.models.enums import Location, SeverityLevel
+from app.models.enums import Location, SeverityLevel, TriState
 
 # map severity level to their index
 severity_level_dict = {level.value: i for i, level in enumerate(SeverityLevel)}
@@ -67,7 +67,8 @@ def generate_alerts(events: list[EarthquakeEvent]) -> list[EarthquakeAlert]:
                 origin_time=event.origin_time,
                 location=event.location,
                 severity_level=event.severity_level,
-                status="unprocessed",
+                has_damage=TriState.UNKNOWN,
+                needs_command_center=TriState.UNKNOWN,
                 processing_furation=0,  # Add real logic later
             )
             alerts.append(alert)

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -1,6 +1,6 @@
 from prometheus_client import Counter, Gauge
 
-from app.models.earthquake import EarthquakeData
+from app.models.earthquake import EarthquakeAlert, EarthquakeData, EarthquakeEvent
 
 # --- Earthquake data metrics ---
 earthquake_occurrences_total = Counter(
@@ -62,6 +62,7 @@ earthquake_events_severity = Gauge(
     ["source", "id", "location"],
 )
 
+
 # --- Earthquake alert metrics ---
 earthquake_alerts_total = Counter(
     "earthquake_alerts_total",
@@ -71,30 +72,18 @@ earthquake_alerts_total = Counter(
 earthquake_alerts_damage = Gauge(
     "earthquake_alerts_damage",
     "Flag of whether there is damage in earthquake alerts",
-    ["source", "id", "location"],
+    ["source", "id", "location, origin_time"],
 )
 earthquake_alerts_command_center = Gauge(
     "earthquake_alerts_command_center",
     "Flag of whether command center is needed in earthquake alerts",
-    ["source", "id", "location"],
+    ["source", "id", "location, origin_time"],
 )
 earthquake_alerts_processing_duration = Gauge(
     "earthquake_alerts_processing_duration",
     "Processing duration of earthquake alerts",
-    ["source", "id", "location"],
+    ["source", "id", "location, origin_time"],
 )
 
-# def observe_earthquake_alerts(alert: EarthquakeData) -> None:
-#     # increment alert counter
-#     earthquake_alerts_total.labels(source=alert.source).inc()
 
-#     # set damage and command center flags
-#     earthquake_alerts_damage.labels(
-#         id=str(alert.id),
-#         source=alert.source,
-#     ).set(alert.has_damage.value)
-#     earthquake_alerts_command_center.labels(
-#         id=str(alert.id),
-#         source=alert.source,
-#         epicenter=alert.epicenter_location,
-#     ).set(alert.needs_command_center.value)
+

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -48,3 +48,53 @@ def observe_earthquake_data(data: EarthquakeData) -> None:
             source=data.source,
             area=area.county_name.value,
         ).set(area.area_intensity)
+
+
+# --- Earthquake event metrics ---
+earthquake_events_total = Counter(
+    "earthquake_events_total",
+    "Total number of earthquake events",
+    ["source"],
+)
+earthquake_events_severity = Gauge(
+    "earthquake_events_severity",
+    "Severity level of earthquake events",
+    ["source", "id", "location"],
+)
+
+# --- Earthquake alert metrics ---
+earthquake_alerts_total = Counter(
+    "earthquake_alerts_total",
+    "Total number of earthquake alerts",
+    ["source"],
+)
+earthquake_alerts_damage = Gauge(
+    "earthquake_alerts_damage",
+    "Flag of whether there is damage in earthquake alerts",
+    ["source", "id", "location"],
+)
+earthquake_alerts_command_center = Gauge(
+    "earthquake_alerts_command_center",
+    "Flag of whether command center is needed in earthquake alerts",
+    ["source", "id", "location"],
+)
+earthquake_alerts_processing_duration = Gauge(
+    "earthquake_alerts_processing_duration",
+    "Processing duration of earthquake alerts",
+    ["source", "id", "location"],
+)
+
+# def observe_earthquake_alerts(alert: EarthquakeData) -> None:
+#     # increment alert counter
+#     earthquake_alerts_total.labels(source=alert.source).inc()
+
+#     # set damage and command center flags
+#     earthquake_alerts_damage.labels(
+#         id=str(alert.id),
+#         source=alert.source,
+#     ).set(alert.has_damage.value)
+#     earthquake_alerts_command_center.labels(
+#         id=str(alert.id),
+#         source=alert.source,
+#         epicenter=alert.epicenter_location,
+#     ).set(alert.needs_command_center.value)

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -62,6 +62,17 @@ earthquake_events_severity = Gauge(
     ["source", "id", "location"],
 )
 
+def observe_earthquake_events(event: EarthquakeEvent) -> None:
+    # increment event counter
+    earthquake_events_total.labels(source=event.source).inc()
+
+    # set severity level
+    earthquake_events_severity.labels(
+        id=str(event.id),
+        source=event.source,
+        location=event.location.value,
+    ).set(event.severity_level.value)
+
 
 # --- Earthquake alert metrics ---
 earthquake_alerts_total = Counter(
@@ -84,6 +95,37 @@ earthquake_alerts_processing_duration = Gauge(
     "Processing duration of earthquake alerts",
     ["source", "id", "location, origin_time"],
 )
+
+
+def observe_earthquake_alerts(alert: EarthquakeAlert) -> None:
+    # increment alert counter
+    earthquake_alerts_total.labels(source=alert.source).inc()
+
+    # set damage and command center flags
+    earthquake_alerts_damage.labels(
+        id=str(alert.id),
+        source=alert.source,
+        location=alert.location.value,
+        origin_time=alert.origin_time.isoformat(),
+    ).set(alert.has_damage.value)
+    earthquake_alerts_command_center.labels(
+        id=str(alert.id),
+        source=alert.source,
+        location=alert.location.value,
+        origin_time=alert.origin_time.isoformat(),
+    ).set(alert.needs_command_center.value)
+    # set processing duration
+    earthquake_alerts_processing_duration.labels(
+        id=str(alert.id),
+        source=alert.source,
+        location=alert.location.value,
+        origin_time=alert.origin_time.isoformat(),
+    ).set(alert.processing_duration)
+
+
+def observe_earthquake_alert_report() -> None:
+    # TODO: update alert's attributes : has_damage, needs_command_center, processing_duration
+    pass
 
 
 

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -62,6 +62,7 @@ earthquake_events_severity = Gauge(
     ["source", "id", "location"],
 )
 
+
 def observe_earthquake_events(event: EarthquakeEvent) -> None:
     # increment event counter
     earthquake_events_total.labels(source=event.source).inc()
@@ -83,17 +84,17 @@ earthquake_alerts_total = Counter(
 earthquake_alerts_damage = Gauge(
     "earthquake_alerts_damage",
     "Flag of whether there is damage in earthquake alerts",
-    ["source", "id", "location, origin_time"],
+    ["source", "id", "location", "origin_time"],
 )
 earthquake_alerts_command_center = Gauge(
     "earthquake_alerts_command_center",
     "Flag of whether command center is needed in earthquake alerts",
-    ["source", "id", "location, origin_time"],
+    ["source", "id", "location", "origin_time"],
 )
 earthquake_alerts_processing_duration = Gauge(
     "earthquake_alerts_processing_duration",
     "Processing duration of earthquake alerts",
-    ["source", "id", "location, origin_time"],
+    ["source", "id", "location", "origin_time"],
 )
 
 
@@ -126,6 +127,3 @@ def observe_earthquake_alerts(alert: EarthquakeAlert) -> None:
 def observe_earthquake_alert_report() -> None:
     # TODO: update alert's attributes : has_damage, needs_command_center, processing_duration
     pass
-
-
-


### PR DESCRIPTION
This PR mainly add Prometheus event and alert metrics, including some minor changes : previous attribute ```status``` in EarthquakeAlert is changed to ```has_damage``` and ```needs_command_center```

There are some notes and discussion to be discussed with, but first you can just see if everything goes right
- Currently implementation of Alert metric, such as ```earthquake_alerts_damage```, ```earthquake_alerts_command_center```, ```earthquake_alerts_processing_duration``` will be scratched first with initial value (UNKNOWN = -1, UNKNOWN = -1, 0) and then be overwritten after the report.
    - Report needs to specify the old alert's label : ```["source", "id", "location"]```, and need to compute ```processing_duration``` by the old alert's label ```origin_time```
    - The Overwrite after the report doesn't delete the old alert, and Grafana will only show the latest alert
    - When issuing alert, if you don't want the above scenario (old alert still exists) and the metric ```earthquake_alerts_damage```, ```earthquake_alerts_command_center```, ```earthquake_alerts_processing_duration``` be not scratched, it still needs to scratch ```origin_time``` for later ```processing_duration``` computation
