### PR TITLE
chore: refactor class SeverityLevel & EarthquakeAlert

### DIFF
--- a/app/models/earthquake.py
+++ b/app/models/earthquake.py
@@ -30,12 +30,7 @@ class EarthquakeEvent(BaseModel):
     severity_level: SeverityLevel
 
 
-class EarthquakeAlert(BaseModel):
-    id: str
-    source: str
-    origin_time: datetime
-    location: Location
-    severity_level: SeverityLevel
+class EarthquakeAlert(EarthquakeEvent):
     has_damage: TriState
     needs_command_center: TriState
     processing_duration: int

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -9,9 +9,9 @@ class Location(str, Enum):
 
 
 class SeverityLevel(str, Enum):
-    NA = "NA"
-    L1 = "L1"
-    L2 = "L2"
+    NA = 0
+    L1 = 1
+    L2 = 2
 
 
 class TriState(int, Enum):

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -8,7 +8,7 @@ class Location(str, Enum):
     TAINAN = "Tainan"
 
 
-class SeverityLevel(str, Enum):
+class SeverityLevel(int, Enum):
     NA = 0
     L1 = 1
     L2 = 2

--- a/app/services/earthquake.py
+++ b/app/services/earthquake.py
@@ -5,9 +5,6 @@ from app.core.redis import get_alert_suppress_time, redis_client
 from app.models.earthquake import EarthquakeAlert, EarthquakeData, EarthquakeEvent
 from app.models.enums import Location, SeverityLevel, TriState
 
-# map severity level to their index
-severity_level_dict = {level.value: i for i, level in enumerate(SeverityLevel)}
-
 
 def generate_events(data: EarthquakeData) -> list[EarthquakeEvent]:
     events = []
@@ -52,10 +49,12 @@ def generate_alerts(events: list[EarthquakeEvent]) -> list[EarthquakeAlert]:
             )
 
             # current event should be suppressed
-            if severity_level_dict[event.severity_level.value] <= severity_level_dict[
-                cached_severity_level
-            ] and event.origin_time - cached_origin_time <= timedelta(
-                seconds=alert_suppress_time,
+            if (
+                event.severity_level.value <= cached_severity_level
+                and event.origin_time - cached_origin_time
+                <= timedelta(
+                    seconds=alert_suppress_time,
+                )
             ):
                 continue
 

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -1,11 +1,6 @@
 from prometheus_client import Counter, Gauge
 
 from app.models.earthquake import EarthquakeAlert, EarthquakeData, EarthquakeEvent
-from app.models.enums import SeverityLevel
-
-# map severity level to their index
-severity_level_dict = {level.value: i for i, level in enumerate(SeverityLevel)}
-
 
 # --- Earthquake data metrics ---
 earthquake_occurrences_total = Counter(
@@ -76,7 +71,7 @@ def observe_earthquake_events(events: list[EarthquakeEvent]) -> None:
             id=str(event.id),
             source=event.source,
             location=event.location.value,
-        ).set(severity_level_dict[event.severity_level.value])
+        ).set(event.severity_level.value)
 
 
 # --- Earthquake alert metrics ---


### PR DESCRIPTION
This PR refactor the class ```SeverityLevel``` and ```EarthquakeAlert``` :

```python
class SeverityLevel(int, Enum):
    NA = 0
    L1 = 1
    L2 = 2
```
```python
class EarthquakeAlert(EarthquakeEvent):
    has_damage: TriState
    needs_command_center: TriState
    processing_duration: int
```
Fix #36 