### PR TITLE
feat: Add Grafana configuration in docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ REDIS_PORT=6379
 
 # === Alert ===
 ALERT_SUPPRESS_TIME=60
+
+# === Grafana ===
+GF_SECURITY_ADMIN_USER=admin
+GF_SECURITY_ADMIN_PASSWORD=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,21 @@ services:
       - "6379:6379"
     networks:
       - monitor-network
+  
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - monitor-network
+    depends_on:
+      - prometheus
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER}
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
 
 networks:
   monitor-network:
@@ -46,3 +61,4 @@ networks:
 
 volumes:
   redis-data:
+  grafana-storage:


### PR DESCRIPTION
This PR setups basic configuration of Grafana, you can follow the steps :
1. add your own ```GF_SECURITY_ADMIN_USER``` and ```GF_SECURITY_ADMIN_USER``` to .env (both ```admin``` in .env.example)
2. re-build the image and run
3. login and add Prometheus as a data source (left side bar : Connections -> Data sources)
4. you can now try anything such as create dashboards to visualize metrics

Fix #32 