### PR TITLE
chore: Added endpoint to clear Redis cache

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.models.response import Response
-from app.routers import earthquake, settings
+from app.routers import earthquake, settings, redis
 
 app = FastAPI()
 Instrumentator().instrument(app).expose(app)
@@ -19,6 +19,7 @@ app.add_middleware(
 
 app.include_router(earthquake.router)
 app.include_router(settings.router)
+app.include_router(redis.router)
 
 
 @app.get("/")

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.models.response import Response
-from app.routers import earthquake, settings, redis
+from app.routers import earthquake, redis, settings
 
 app = FastAPI()
 Instrumentator().instrument(app).expose(app)

--- a/app/routers/redis.py
+++ b/app/routers/redis.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter
+
+from app.core.redis import redis_client
+from app.models.response import Response
+
+router = APIRouter(prefix="/api/redis", tags=["redis"])
+
+
+@router.delete("/")
+def clear_cache() -> Response:
+    redis_client.flushdb()
+    return {"message": "Clear redis cache successfully"}


### PR DESCRIPTION
## Description
This PR adds a new DELETE endpoint at `/api/redis/` to allow clearing the entire Redis cache. This endpoint is useful for clearing previously stored alerts or cached data during development and testing.
