### PR TITLE
feat: Add Grafana dashboard configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ wheels/
 
 # Environment variable files
 .env
+
+# local file system
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,8 @@ services:
     container_name: grafana
     volumes:
       - grafana-storage:/var/lib/grafana
-      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ./grafana/provisioning:/etc/grafana/provisioning
       - ./grafana/dashboards:/var/lib/grafana/dashboards
-      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
     ports:
       - "3000:3000"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     container_name: grafana
     volumes:
       - grafana-storage:/var/lib/grafana
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
       - ./grafana/dashboards:/var/lib/grafana/dashboards
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     container_name: grafana
     volumes:
       - grafana-storage:/var/lib/grafana
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
     ports:
       - "3000:3000"
     networks:

--- a/grafana/dashboards/sample-dashboard.json
+++ b/grafana/dashboards/sample-dashboard.json
@@ -1,0 +1,172 @@
+{
+  "id": null,
+  "title": "Earthquake Monitoring Dashboard",
+  "timezone": "UTC+8",
+  "schemaVersion": 16,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Total Earthquake Occurrences",
+      "id": 1,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "earthquake_occurrences_total{}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Earthquake Magnitude",
+      "id": 2,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "x": 0,
+        "y": 9,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "earthquake_magnitude{}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Earthquake Depth",
+      "id": 3,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "x": 0,
+        "y": 18,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "earthquake_depth{}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Earthquake Intensity",
+      "id": 4,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "x": 0,
+        "y": 27,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "earthquake_intensity{}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Earthquake Event Count",
+      "id": 5,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "x": 0,
+        "y": 36,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "earthquake_events_total",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Earthquake Event Severity",
+      "id": 6,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "x": 0,
+        "y": 45,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "earthquake_event_severity_level",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Earthquake Alert Count",
+      "id": 7,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "x": 0,
+        "y": 54,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "earthquake_alerts_total",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Earthquake Alerts with Damage",
+      "id": 8,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "x": 0,
+        "y": 63,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "earthquake_alerts_damage",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Earthquake Alerts with Command Center Need",
+      "id": 9,
+      "datasource": "Prometheus",
+      "gridPos": {
+        "x": 0,
+        "y": 72,
+        "w": 24,
+        "h": 9
+      },
+      "targets": [
+        {
+          "expr": "earthquake_alerts_command_center",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/provisioning/dashboards/dashboards.yaml
+++ b/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+# grafana/provisioning/datasources/datasource.yml
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true


### PR DESCRIPTION
# Description
This PR add the basic dashboard configuration with a simple dashboard sample, some notes below:
- you need to re-build and run
- your data source's name on the Grafana web UI needs to be exactly the same as the data source defined inside ```grafana/dashboards/sample-dashboard.json``` or ```grafana/provisioning/datasources/datasource.yml```, otherwise it will fail on connection
<img width="1502" alt="截圖 2025-05-09 下午5 13 25" src="https://github.com/user-attachments/assets/5716c85b-5611-4bad-bcf3-cd7d975eda85" />

Fix #41 