### PR TITLE
chore: Refactor EarthquakeAlert class

### DIFF
--- a/app/models/earthquake.py
+++ b/app/models/earthquake.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 from pydantic import Field
 
 from .base import CustomBaseModel
-from .enums import Location, SeverityLevel, TriState
+from .enums import AlertStatus, Location, SeverityLevel, TriState
 
 
 class ShakingArea(CustomBaseModel):
@@ -31,6 +31,7 @@ class EarthquakeEvent(CustomBaseModel):
 
 
 class EarthquakeAlert(EarthquakeEvent):
+    status: AlertStatus
     has_damage: TriState
     needs_command_center: TriState
     processing_duration: int

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -18,3 +18,9 @@ class TriState(int, Enum):
     TRUE = 1
     FALSE = 0
     UNKNOWN = -1
+
+
+class AlertStatus(int, Enum):
+    CLOSED = 1
+    OPEN = 0
+    AUTOCLOSE = -1

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -23,4 +23,4 @@ class TriState(int, Enum):
 class AlertStatus(int, Enum):
     CLOSED = 1
     OPEN = 0
-    AUTOCLOSE = -1
+    AUTOCLOSED = -1

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -20,7 +20,7 @@ class TriState(int, Enum):
     UNKNOWN = -1
 
 
-class AlertStatus(int, Enum):
-    CLOSED = 1
-    OPEN = 0
-    AUTOCLOSED = -1
+class AlertStatus(str, Enum):
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    AUTOCLOSED = "AUTOCLOSED"


### PR DESCRIPTION
# Description

This PR refactor class ```EarthquakeAlert``` to 
```python
class EarthquakeAlert(EarthquakeEvent):
    status: AlertStatus
    has_damage: TriState
    needs_command_center: TriState
    processing_duration: int
```
with class ```AlertStatus``` be 
```python
class AlertStatus(int, Enum):
    CLOSED = 1
    OPEN = 0
    AUTOCLOSED = -1
```

Note that you may need to clear redis first