### PR TITLE
chore: Filter alerts by open status

### DIFF
--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -1,7 +1,12 @@
+import json
 import os
+from typing import TypeVar
 
 import redis
 from dotenv import load_dotenv
+from pydantic import BaseModel, ValidationError
+
+T = TypeVar("T", bound=BaseModel)
 
 # load env variables
 load_dotenv()
@@ -19,3 +24,26 @@ def get_alert_suppress_time() -> int:
     # return default time from env if not found in cache
     time = redis_client.get("ALERT_SUPPRESS_TIME")
     return int(time) if time else ALERT_SUPPRESS_TIME
+
+
+def get_data_by_prefix(prefix: str, model: type[T]) -> list[T]:
+    cursor = 0
+    results: list[T] = []
+
+    pattern = f"{prefix}_*"
+
+    while True:
+        cursor, keys = redis_client.scan(cursor=cursor, match=pattern, count=100)
+        for key in keys:
+            raw = redis_client.get(key)
+            if raw:
+                try:
+                    # decode bytes to string if necessary
+                    raw_str = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+                    results.append(model.model_validate_json(raw_str))
+                except (ValidationError, json.JSONDecodeError):
+                    continue
+        if cursor == 0:
+            break
+
+    return results

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -22,5 +22,5 @@ class TriState(int, Enum):
 
 class AlertStatus(str, Enum):
     OPEN = "OPEN"
-    RESPONDED = "RESPONDED"
+    PROCESSED = "PROCESSED"
     AUTOCLOSED = "AUTOCLOSED"

--- a/app/models/enums.py
+++ b/app/models/enums.py
@@ -21,6 +21,6 @@ class TriState(int, Enum):
 
 
 class AlertStatus(str, Enum):
-    CLOSED = "CLOSED"
     OPEN = "OPEN"
+    RESPONDED = "RESPONDED"
     AUTOCLOSED = "AUTOCLOSED"

--- a/app/routers/earthquake.py
+++ b/app/routers/earthquake.py
@@ -1,9 +1,8 @@
-import json
-
 from fastapi import APIRouter
 
-from app.core.redis import redis_client
+from app.core.redis import get_data_by_prefix
 from app.models.earthquake import EarthquakeAlert, EarthquakeData
+from app.models.enums import AlertStatus
 from app.models.response import Response
 from app.services.earthquake import process_earthquake_data
 
@@ -18,20 +17,15 @@ def create_earthquake(data: EarthquakeData) -> Response:
 
 @router.get("/alerts")
 def get_earthquake_alerts() -> Response[list[EarthquakeAlert]]:
-    cursor = 0
-    alerts = []
+    alerts = get_data_by_prefix("alert", EarthquakeAlert)
+    alerts.sort(
+        key=lambda alert: (
+            -alert.origin_time.timestamp(),
+            alert.location.value,
+            alert.source,
+        ),
+    )
 
-    # get all alerts data from redis cache
-    while True:
-        cursor, keys = redis_client.scan(cursor=cursor, match="alert_*", count=100)
-        for key in keys:
-            alert_data = redis_client.get(key)
-            if alert_data:
-                try:
-                    alerts.append(json.loads(alert_data))
-                except json.JSONDecodeError:
-                    continue
-        if cursor == 0:
-            break
-
-    return {"message": f"Found {len(alerts)} alerts data", "data": alerts}
+    # filter only alerts where status is OPEN
+    open_alerts = [alert for alert in alerts if alert.status == AlertStatus.OPEN]
+    return {"message": f"Found {len(open_alerts)} alerts data", "data": open_alerts}


### PR DESCRIPTION
## Description
This PR updates the backend logic to filter cached earthquake alerts to include only those with an OPEN status.