### PR TITLE
feat: Added endpoint for processing earthquake alert

### DIFF
--- a/app/models/earthquake.py
+++ b/app/models/earthquake.py
@@ -34,4 +34,5 @@ class EarthquakeAlert(EarthquakeEvent):
     status: AlertStatus
     has_damage: TriState
     needs_command_center: TriState
+    processed_time: datetime | None = None
     processing_duration: int

--- a/app/routers/earthquake.py
+++ b/app/routers/earthquake.py
@@ -1,6 +1,6 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
-from app.core.redis import get_data_by_prefix
+from app.core.redis import get_data_by_prefix, redis_client
 from app.models.earthquake import EarthquakeAlert, EarthquakeData
 from app.models.enums import AlertStatus
 from app.models.response import Response
@@ -29,3 +29,21 @@ def get_earthquake_alerts() -> Response[list[EarthquakeAlert]]:
     # filter only alerts where status is OPEN
     open_alerts = [alert for alert in alerts if alert.status == AlertStatus.OPEN]
     return {"message": f"Found {len(open_alerts)} alerts data", "data": open_alerts}
+
+
+@router.put("/alerts/{alert_id}")
+def process_earthquake_alert(alert_id: str, alert: EarthquakeAlert) -> Response:
+    # determine if processed alert is still in redis cache
+    redis_key = f"alert_{alert.source}_{alert.location.value}_{alert_id}"
+    cached_alert = redis_client.get(redis_key)
+    if not cached_alert:
+        raise HTTPException(status_code=404, detail="Alert not found")
+
+    # update processing duration
+    alert.processing_duration = alert.processed_time - alert.origin_time
+
+    # TODO: update alert metrics
+
+    # delete alert from redis
+    redis_client.delete(redis_key)
+    return {"message": f"Processed alert {alert_id} successfully"}


### PR DESCRIPTION
## Description
This PR added PUT `/api/earthquake/alerts/{alert_id}` endpoint to handle the processing of earthquake alerts.
- The endpoint:
  - Validates that the alert exists in Redis.
  - Calculates and updates the alert’s `processing_duration` based on `processed_time` and `origin_time`.
  - Removes the processed alert from Redis to free up memory.
- Future work: update relevant alert metrics.