### PR TITLE
feat: Migrate to async Redis client

### DIFF
--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -2,9 +2,9 @@ import json
 import os
 from typing import TypeVar
 
-from redis.asyncio import Redis
 from dotenv import load_dotenv
 from pydantic import BaseModel, ValidationError
+from redis.asyncio import Redis
 
 T = TypeVar("T", bound=BaseModel)
 

--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import TypeVar
 
-import redis
+from redis.asyncio import Redis
 from dotenv import load_dotenv
 from pydantic import BaseModel, ValidationError
 
@@ -16,26 +16,26 @@ ALERT_SUPPRESS_TIME = int(os.getenv("ALERT_SUPPRESS_TIME"))
 
 
 # initialize redis connection
-redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=0)
+redis_client = Redis(host=REDIS_HOST, port=REDIS_PORT, db=0)
 
 
-def get_alert_suppress_time() -> int:
+async def get_alert_suppress_time() -> int:
     # get alert suppress time from cache
     # return default time from env if not found in cache
-    time = redis_client.get("ALERT_SUPPRESS_TIME")
+    time = await redis_client.get("ALERT_SUPPRESS_TIME")
     return int(time) if time else ALERT_SUPPRESS_TIME
 
 
-def get_data_by_prefix(prefix: str, model: type[T]) -> list[T]:
+async def get_data_by_prefix(prefix: str, model: type[T]) -> list[T]:
     cursor = 0
     results: list[T] = []
 
     pattern = f"{prefix}_*"
 
     while True:
-        cursor, keys = redis_client.scan(cursor=cursor, match=pattern, count=100)
+        cursor, keys = await redis_client.scan(cursor=cursor, match=pattern, count=100)
         for key in keys:
-            raw = redis_client.get(key)
+            raw = await redis_client.get(key)
             if raw:
                 try:
                     # decode bytes to string if necessary

--- a/app/routers/redis.py
+++ b/app/routers/redis.py
@@ -7,6 +7,6 @@ router = APIRouter(prefix="/api/redis", tags=["redis"])
 
 
 @router.delete("/")
-def clear_cache() -> Response:
-    redis_client.flushdb()
+async def clear_cache() -> Response:
+    await redis_client.flushdb()
     return {"message": "Clear redis cache successfully"}

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -8,8 +8,8 @@ router = APIRouter(prefix="/api/settings", tags=["settings"])
 
 
 @router.put("/alert-suppress-time")
-def set_suppress_time(data: Settings) -> Response[str]:
-    redis_client.set("ALERT_SUPPRESS_TIME", str(data.alert_suppress_time))
+async def set_suppress_time(data: Settings) -> Response[str]:
+    await redis_client.set("ALERT_SUPPRESS_TIME", str(data.alert_suppress_time))
     return {
         "message": f"Updated to {data.alert_suppress_time} seconds successfully",
         "data": f"{data.alert_suppress_time}",
@@ -17,8 +17,8 @@ def set_suppress_time(data: Settings) -> Response[str]:
 
 
 @router.get("/alert-suppress-time")
-def get_suppress_time() -> Response[str]:
-    time = get_alert_suppress_time()
+async def get_suppress_time() -> Response[str]:
+    time = await get_alert_suppress_time()
     return {
         "message": f"The current suppress time is {time} seconds",
         "data": f"{time}",


### PR DESCRIPTION
## Description
This PR refactors the application to use the async Redis client (`redis.asyncio`) instead of the synchronous `redis-py` client. This change is necessary to handle Redis operations efficiently in a non-blocking way, particularly for WebSocket communication and Redis Pub/Sub functionality in the future.