### PR TITLE
chore: Added default env fallbacks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,4 @@ jobs:
         run: uv run ruff check .
       
       - name: Run tests
-        run: |
-          cp .env.example .env
-          uv run pytest -v 
+        run: uv run pytest -v 

--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -10,9 +10,9 @@ T = TypeVar("T", bound=BaseModel)
 
 # load env variables
 load_dotenv()
-REDIS_HOST = os.getenv("REDIS_HOST")
-REDIS_PORT = int(os.getenv("REDIS_PORT"))
-ALERT_SUPPRESS_TIME = int(os.getenv("ALERT_SUPPRESS_TIME"))
+REDIS_HOST = os.getenv("REDIS_HOST", "redis")
+REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+ALERT_SUPPRESS_TIME = int(os.getenv("ALERT_SUPPRESS_TIME", "600"))
 
 
 # initialize redis connection


### PR DESCRIPTION
## Description
This PR adds default fallback values for critical environment variables such as:
- `REDIS_HOST`
- `REDIS_PORT`
- `ALERT_SUPPRESS_TIME`

> With this update, tests can run successfully in CI without relying on `.env` files.