### PR TITLE
chore: Changed alert expiration time

### DIFF
--- a/app/routers/earthquake.py
+++ b/app/routers/earthquake.py
@@ -73,7 +73,7 @@ async def autoclose_expired_alerts() -> Response:
 
         # current alert is not responded within 1 hr
         if alert.status == AlertStatus.OPEN and (now - alert.origin_time) > timedelta(
-            hours=1,
+            minutes=1,
         ):
             # set alert status as autoclosed
             alert.status = AlertStatus.AUTOCLOSED


### PR DESCRIPTION
## Description
This PR modifies the alert expiration logic to consider alerts not responded after 1 minute as expired instead of 1 hour, specifically to facilitate faster feedback during demos and testing.