### PR TITLE
chore: Reverted alert expiration time

### DIFF
--- a/app/routers/earthquake.py
+++ b/app/routers/earthquake.py
@@ -73,7 +73,7 @@ async def autoclose_expired_alerts() -> Response:
 
         # current alert is not responded within 1 hr
         if alert.status == AlertStatus.OPEN and (now - alert.origin_time) > timedelta(
-            minutes=1,
+            hours=1,
         ):
             # set alert status as autoclosed
             alert.status = AlertStatus.AUTOCLOSED


### PR DESCRIPTION
## Description
This PR reverted the alert expiration logic to consider alerts not responded after 1 hour as expired instead of 1 min set previously.