### PR TITLE
chore: Added WebSocket ping mechanism for connection keep-alive

### DIFF
--- a/app/websockets/alerts_ws.py
+++ b/app/websockets/alerts_ws.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from .manager import manager
@@ -10,6 +12,7 @@ async def alerts_websocket(websocket: WebSocket) -> None:
     await manager.connect(websocket)
     try:
         while True:
-            await websocket.receive_text()  # keep alive
+            await websocket.send_text("ping")
+            await asyncio.sleep(60)
     except WebSocketDisconnect:
         manager.disconnect(websocket)


### PR DESCRIPTION
## Description
This PR introduces a periodic ping system for the WebSocket endpoint (`/ws/alerts`) to ensure client connections remain alive, especially when idle for extended periods.