### PR TITLE
feat: Added centralized application logger

### DIFF
--- a/app/utils/logger.py
+++ b/app/utils/logger.py
@@ -1,0 +1,14 @@
+import logging
+
+# Configure logger
+logger = logging.getLogger("backend")
+logger.setLevel(logging.INFO)
+
+# Avoid duplicate handlers when re-imported
+if not logger.hasHandlers():
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)

--- a/app/utils/logger.py
+++ b/app/utils/logger.py
@@ -1,7 +1,7 @@
 import logging
 
 # Configure logger
-logger = logging.getLogger("backend")
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # Avoid duplicate handlers when re-imported

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -1,0 +1,23 @@
+import logging
+
+from _pytest.logging import LogCaptureFixture
+
+from app.utils.logger import logger
+
+
+def test_logger_outputs_info_level(caplog: LogCaptureFixture) -> None:
+    # Set logger level to INFO and enable caplog capturing
+    with caplog.at_level(logging.INFO, logger="backend"):
+        logger.info("This is a test log message.")
+
+    # Check that message appears in logs
+    assert "This is a test log message." in caplog.text
+    assert "INFO" in caplog.text
+    assert "backend" in caplog.text
+
+
+def test_logger_does_not_output_debug_by_default(caplog: LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO, logger="backend"):
+        logger.debug("This debug message should not appear.")
+
+    assert "This debug message should not appear." not in caplog.text

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -7,17 +7,16 @@ from app.utils.logger import logger
 
 def test_logger_outputs_info_level(caplog: LogCaptureFixture) -> None:
     # Set logger level to INFO and enable caplog capturing
-    with caplog.at_level(logging.INFO, logger="backend"):
+    with caplog.at_level(logging.INFO):
         logger.info("This is a test log message.")
 
     # Check that message appears in logs
     assert "This is a test log message." in caplog.text
     assert "INFO" in caplog.text
-    assert "backend" in caplog.text
 
 
 def test_logger_does_not_output_debug_by_default(caplog: LogCaptureFixture) -> None:
-    with caplog.at_level(logging.INFO, logger="backend"):
+    with caplog.at_level(logging.INFO):
         logger.debug("This debug message should not appear.")
 
     assert "This debug message should not appear." not in caplog.text


### PR DESCRIPTION
## Description
This PR introduces a centralized logging setup to enable consistent, structured logging across the application. The logger is defined once and can be reused in all modules, including routers, background tasks, and utilities.